### PR TITLE
Rustyify conversions

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -645,7 +645,7 @@ mod tests {
         });
 
         let who_is_apdu = Apdu::UnconfirmedRequest {
-            service_choice: UnconfirmedServiceChoice::WhoIs as u8,
+            service_choice: UnconfirmedServiceChoice::WhoIs,
             service_data: vec![],
         };
 
@@ -654,7 +654,7 @@ mod tests {
         
         match response.unwrap() {
             Apdu::UnconfirmedRequest { service_choice, .. } => {
-                assert_eq!(service_choice, UnconfirmedServiceChoice::IAm as u8);
+                assert_eq!(service_choice, UnconfirmedServiceChoice::IAm);
             },
             _ => panic!("Expected I-Am response"),
         }

--- a/examples/basic/advanced_device.rs
+++ b/examples/basic/advanced_device.rs
@@ -214,7 +214,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         invoke_id: 42,
         sequence_number: None,
         proposed_window_size: None,
-        service_choice: ConfirmedServiceChoice::WriteProperty as u8,
+        service_choice: ConfirmedServiceChoice::WriteProperty,
         service_data: write_data,
     };
 
@@ -231,7 +231,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         invoke_id: 43,
         sequence_number: None,
         proposed_window_size: None,
-        service_choice: ConfirmedServiceChoice::SubscribeCOV as u8,
+        service_choice: ConfirmedServiceChoice::SubscribeCOV,
         service_data: cov_buffer,
     };
 

--- a/examples/basic/simple_device.rs
+++ b/examples/basic/simple_device.rs
@@ -13,6 +13,7 @@ use bacnet_rs::{
     network::Npdu,
     object::{BacnetObject, Device, ObjectIdentifier, ObjectType, PropertyIdentifier},
     service::{IAmRequest, ReadPropertyRequest, UnconfirmedServiceChoice, WhoIsRequest},
+    ConfirmedServiceChoice,
 };
 
 use std::net::SocketAddr;
@@ -91,7 +92,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Unconfirmed request (Who-Is)
     let whois_apdu = Apdu::UnconfirmedRequest {
-        service_choice: UnconfirmedServiceChoice::WhoIs as u8,
+        service_choice: UnconfirmedServiceChoice::WhoIs,
         service_data: whois_buffer,
     };
 
@@ -101,7 +102,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let decoded_apdu = Apdu::decode(&encoded_apdu)?;
     match decoded_apdu {
         Apdu::UnconfirmedRequest { service_choice, .. } => {
-            println!("Decoded APDU service choice: {}", service_choice);
+            println!("Decoded APDU service choice: {:?}", service_choice);
         }
         _ => println!("Unexpected APDU type"),
     }
@@ -121,7 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         invoke_id: 42,
         sequence_number: None,
         proposed_window_size: None,
-        service_choice: 12, // Read Property
+        service_choice: ConfirmedServiceChoice::ReadProperty, // Read Property
         service_data: read_prop_data,
     };
 

--- a/examples/debugging/debug_properties.rs
+++ b/examples/debugging/debug_properties.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &socket,
         target_addr,
         invoke_id,
-        ConfirmedServiceChoice::ReadPropertyMultiple as u8,
+        ConfirmedServiceChoice::ReadPropertyMultiple,
         &encode_rpm_request(&rpm_request)?,
     )?;
 
@@ -278,7 +278,7 @@ fn send_confirmed_request(
     socket: &UdpSocket,
     target_addr: SocketAddr,
     invoke_id: u8,
-    service_choice: u8,
+    service_choice: ConfirmedServiceChoice,
     service_data: &[u8],
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let apdu = Apdu::ConfirmedRequest {

--- a/examples/objects/device_objects.rs
+++ b/examples/objects/device_objects.rs
@@ -758,7 +758,7 @@ fn read_device_object_list(
         socket,
         target_addr,
         invoke_id,
-        ConfirmedServiceChoice::ReadPropertyMultiple as u8,
+        ConfirmedServiceChoice::ReadPropertyMultiple,
         &encode_rpm_request(&rpm_request)?,
     )?;
 
@@ -845,7 +845,7 @@ fn read_objects_properties(
             socket,
             target_addr,
             invoke_id,
-            ConfirmedServiceChoice::ReadPropertyMultiple as u8,
+            ConfirmedServiceChoice::ReadPropertyMultiple,
             &encode_rpm_request(&rpm_request)?,
         ) {
             Ok(response_data) => {
@@ -885,7 +885,7 @@ fn send_confirmed_request(
     socket: &UdpSocket,
     target_addr: SocketAddr,
     invoke_id: u8,
-    service_choice: u8,
+    service_choice: ConfirmedServiceChoice,
     service_data: &[u8],
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     // Create confirmed request APDU

--- a/src/client.rs
+++ b/src/client.rs
@@ -129,7 +129,7 @@ impl BacnetClient {
         let response_data = self.send_confirmed_request(
             target_addr,
             invoke_id,
-            ConfirmedServiceChoice::ReadPropertyMultiple as u8,
+            ConfirmedServiceChoice::ReadPropertyMultiple,
             &self.encode_rpm_request(&rpm_request)?,
         )?;
 
@@ -191,7 +191,7 @@ impl BacnetClient {
             match self.send_confirmed_request(
                 target_addr,
                 invoke_id,
-                ConfirmedServiceChoice::ReadPropertyMultiple as u8,
+                ConfirmedServiceChoice::ReadPropertyMultiple,
                 &self.encode_rpm_request(&rpm_request)?,
             ) {
                 Ok(response_data) => {
@@ -268,7 +268,7 @@ impl BacnetClient {
         &self,
         target_addr: SocketAddr,
         invoke_id: u8,
-        service_choice: u8,
+        service_choice: ConfirmedServiceChoice,
         service_data: &[u8],
     ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let apdu = Apdu::ConfirmedRequest {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -194,6 +194,8 @@ pub enum ServiceError {
     Aborted(AbortReason),
     /// Encoding/decoding error
     EncodingError(String),
+    /// Unsupported service choice
+    UnsupportedServiceChoice(u8),
 }
 
 impl fmt::Display for ServiceError {
@@ -205,6 +207,9 @@ impl fmt::Display for ServiceError {
             ServiceError::Rejected(reason) => write!(f, "Service rejected: {:?}", reason),
             ServiceError::Aborted(reason) => write!(f, "Service aborted: {:?}", reason),
             ServiceError::EncodingError(msg) => write!(f, "Encoding error: {}", msg),
+            ServiceError::UnsupportedServiceChoice(choice) => {
+                write!(f, "Unsupported service choice: {}", choice)
+            }
         }
     }
 }
@@ -259,7 +264,42 @@ pub enum ConfirmedServiceChoice {
     AuthRequest = 34,
 }
 
-/// Unconfirmed service choices
+impl TryFrom<u8> for ConfirmedServiceChoice {
+    type Error = ServiceError;
+
+    fn try_from(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(Self::AcknowledgeAlarm),
+            2 => Ok(Self::ConfirmedEventNotification),
+            3 => Ok(Self::GetAlarmSummary),
+            4 => Ok(Self::GetEnrollmentSummary),
+            29 => Ok(Self::GetEventInformation),
+            6 => Ok(Self::AtomicReadFile),
+            7 => Ok(Self::AtomicWriteFile),
+            8 => Ok(Self::AddListElement),
+            9 => Ok(Self::RemoveListElement),
+            10 => Ok(Self::CreateObject),
+            11 => Ok(Self::DeleteObject),
+            12 => Ok(Self::ReadProperty),
+            14 => Ok(Self::ReadPropertyMultiple),
+            15 => Ok(Self::WriteProperty),
+            16 => Ok(Self::WritePropertyMultiple),
+            17 => Ok(Self::DeviceCommunicationControl),
+            20 => Ok(Self::ReinitializeDevice),
+            21 => Ok(Self::VtOpen),
+            22 => Ok(Self::VtClose),
+            23 => Ok(Self::VtData),
+            24 => Ok(Self::Authenticate),
+            25 => Ok(Self::RequestKey),
+            26 => Ok(Self::ReadRange),
+            5 => Ok(Self::SubscribeCOV),
+            28 => Ok(Self::SubscribeCOVProperty),
+            34 => Ok(Self::AuthRequest),
+            _ => Err(ServiceError::UnsupportedServiceChoice(value)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum UnconfirmedServiceChoice {
@@ -272,6 +312,24 @@ pub enum UnconfirmedServiceChoice {
     WhoHas = 7,
     WhoIs = 8,
     UtcTimeSynchronization = 9,
+}
+
+impl TryFrom<u8> for UnconfirmedServiceChoice {
+    type Error = ServiceError;
+
+    fn try_from(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(Self::IHave),
+            1 => Ok(Self::UnconfirmedEventNotification),
+            3 => Ok(Self::UnconfirmedPrivateTransfer),
+            4 => Ok(Self::UnconfirmedTextMessage),
+            6 => Ok(Self::TimeSynchronization),
+            7 => Ok(Self::WhoHas),
+            8 => Ok(Self::WhoIs),
+            9 => Ok(Self::UtcTimeSynchronization),
+            _ => Err(ServiceError::UnsupportedServiceChoice(value)),
+        }
+    }
 }
 
 /// Reject reason codes


### PR DESCRIPTION
Use TryFrom/From traits for conversions instead of separate functions and avoid where not needed.