### PR TITLE
Clippy errors fix

### DIFF
--- a/examples/networking/routed_device_discovery.rs
+++ b/examples/networking/routed_device_discovery.rs
@@ -575,10 +575,11 @@ fn read_property(
 
                             if resp_invoke_id == (invoke_id & 0x0F) {
                                 match pdu_type {
-                                    0x3 => {
+                                    0x3
                                         // PDU_TYPE_COMPLEX_ACK
                                         // Complex ACK format: [PDU_TYPE+invoke_id] [service_choice] [service_data...]
-                                        if apdu_data.len() >= 2 && apdu_data[1] == 0x0C {
+                                    if apdu_data.len() >= 2 && apdu_data[1] == 0x0C =>
+                                        {
                                             // SERVICE_CONFIRMED_READ_PROPERTY
                                             // Parse ReadProperty-ACK service data starting at byte 2
                                             if let Ok(response) =
@@ -597,7 +598,6 @@ fn read_property(
                                                 return parse_read_property_ack_manual(
                                                     &apdu_data[2..],
                                                 );
-                                            }
                                         }
                                     }
                                     0x5 => {

--- a/examples/objects/device_objects.rs
+++ b/examples/objects/device_objects.rs
@@ -1106,36 +1106,32 @@ fn parse_rpm_response(
             .object_identifier
             .object_type
         {
-            ObjectType::AnalogInput | ObjectType::AnalogOutput | ObjectType::AnalogValue => {
-                if pos < data.len() && data[pos] == 0x44 {
-                    // Real value tag
-                    if let Some((value, consumed)) = extract_present_value(
-                        &data[pos..],
-                        objects_info[current_obj_index]
-                            .object_identifier
-                            .object_type,
-                    ) {
-                        // Debug: comment out for clean output
-                        // println!("Debug: Extracted present value: '{}'", value);
-                        objects_info[current_obj_index].present_value = Some(value);
-                        pos += consumed;
-                    }
+            ObjectType::AnalogInput | ObjectType::AnalogOutput | ObjectType::AnalogValue
+                if pos < data.len() && data[pos] == 0x44 =>
+            {
+                // Real value tag
+                if let Some((value, consumed)) = extract_present_value(
+                    &data[pos..],
+                    objects_info[current_obj_index]
+                        .object_identifier
+                        .object_type,
+                ) {
+                    objects_info[current_obj_index].present_value = Some(value);
+                    pos += consumed;
                 }
             }
-            ObjectType::BinaryInput | ObjectType::BinaryOutput | ObjectType::BinaryValue => {
-                if pos < data.len() && data[pos] == 0x11 {
-                    // Boolean value tag
-                    if let Some((value, consumed)) = extract_present_value(
-                        &data[pos..],
-                        objects_info[current_obj_index]
-                            .object_identifier
-                            .object_type,
-                    ) {
-                        // Debug: comment out for clean output
-                        // println!("Debug: Extracted present value: '{}'", value);
-                        objects_info[current_obj_index].present_value = Some(value);
-                        pos += consumed;
-                    }
+            ObjectType::BinaryInput | ObjectType::BinaryOutput | ObjectType::BinaryValue
+                if pos < data.len() && data[pos] == 0x11 =>
+            {
+                // Boolean value tag
+                if let Some((value, consumed)) = extract_present_value(
+                    &data[pos..],
+                    objects_info[current_obj_index]
+                        .object_identifier
+                        .object_type,
+                ) {
+                    objects_info[current_obj_index].present_value = Some(value);
+                    pos += consumed;
                 }
             }
             _ => {}

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -1429,19 +1429,15 @@ pub mod advanced {
                     pos += consumed;
 
                     match tag {
-                        ApplicationTag::CharacterString => {
-                            if length > self.max_string_length {
-                                return Err(EncodingError::InvalidFormat(
-                                    "String too long".to_string(),
-                                ));
-                            }
+                        ApplicationTag::CharacterString if length > self.max_string_length => {
+                            return Err(EncodingError::InvalidFormat(
+                                "String too long".to_string(),
+                            ));
                         }
-                        ApplicationTag::OctetString => {
-                            if length > self.max_string_length * 2 {
-                                return Err(EncodingError::InvalidFormat(
-                                    "Octet string too long".to_string(),
-                                ));
-                            }
+                        ApplicationTag::OctetString if length > self.max_string_length * 2 => {
+                            return Err(EncodingError::InvalidFormat(
+                                "Octet string too long".to_string(),
+                            ));
                         }
                         _ => {}
                     }
@@ -1987,7 +1983,7 @@ impl EncodingAnalyzer {
             .iter()
             .map(|p| (&p.error_type, p.count))
             .collect();
-        errors.sort_by(|a, b| b.1.cmp(&a.1));
+        errors.sort_by_key(|b| std::cmp::Reverse(b.1));
         errors.truncate(limit);
         errors
     }


### PR DESCRIPTION
Refactor conditionals to use `if let` with guards for improved readability and maintainability.