### PR TITLE
Add a client creation function that accepts a specific port for binding

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -65,6 +65,17 @@ impl BacnetClient {
         })
     }
 
+    /// Create a new BACnet client with specific ephemeral port
+    pub fn new_with_local_port(port: u16) -> Result<Self, Box<dyn std::error::Error>> {
+        let socket = UdpSocket::bind(format!("0.0.0.0:{}", port))?;
+        socket.set_read_timeout(Some(Duration::from_secs(5)))?;
+
+        Ok(Self {
+            socket,
+            timeout: Duration::from_secs(5),
+        })
+    }
+
     /// Discover a device by IP address
     pub fn discover_device(
         &self,


### PR DESCRIPTION
I needed to create a BACnet client with a specific port binding instead of a random one because the BACnet server checks the source port.