### PR TITLE
Remove `env_logger` dependency from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ if-addrs = { version = "0.13", optional = true }
 
 # Logging
 log = { version = "0.4", default-features = false }
-env_logger = { version = "0.11", optional = true }
 
 # Time handling
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }


### PR DESCRIPTION
Remove `env_logger` dependency from Cargo.toml as it was optional
#54 proc-macro-error2 is unmaintained
env_logger → jiff → defmt → defmt-macros → proc-macro-error2